### PR TITLE
Use the Keep A Changelog v1.1.0 "types of changes"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,99 +8,103 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 ## Unreleased
 ---
 
-### New
+### Added
+* Added the new CLI flags for the Changelog v1.1 change types
+  * `--added`, `--changed`, `--deprecated`, `--removed`, `--fixed`, `--security`
+### Changed
+* Switched the change type headers in "Unreleased" to match Keep A Changelog v1.1's headers
+  * Existing CHANGELOGs will start using these headers after the new run of `changelog release`
 
-### Changes
-
-### Fixes
+### Fixed
 * Fix Description for pypi
 
-### Breaks
+### Removed
+
 * Removed support for Python 2
 * Removed support for Python 3 prior to 3.6
-
+* Removed the previous CLI flags for the change type headers: `--new`, `--change`, `--fix`, `--breaks`
 
 ## 0.7.0 - (2020-02-09)
 ---
 
-### New
+### Added
 * Expose the type of release with `changelog suggest --type`
 
 
 ## 0.6.2 - (2017-10-27)
 ---
 
-### Fixes
+### Fixed
 * update init template
 
 
 ## 0.6.1 - (2017-07-17)
 ---
 
-### Changes
+### Changed
 * add determinism fuzz testing
 
 
 ## 0.6.0 - (2017-07-16)
 ---
 
-### New
+### Added
 * add view command
 
 
 ## 0.5.4 - (2017-07-16)
 ---
 
-### Changes
+### Changed
 * add 'keep a changelog' regex for parsing
 
 
 ## 0.5.3 - (2017-06-16)
 ---
 
-### Fixes
+### Fixed
 * start first release at 0.1.0
 
 
 ## 0.5.2 - (2017-06-13)
 ---
 
-### Fixes
+### Fixed
 * fixing documentation formatting
 
 
 ## 0.5.1 - (2017-06-13)
 ---
 
-### Fixes
+### Fixed
 * unreleased position in files with shorter headers
 
 
 ## 0.5.0 - (2017-06-13)
 ---
 
-### New
+### Added
 * Added handling for additional version delimiter in changelog files
 
 
 ## 0.4.0 - (2017-06-10)
 ---
 
-### New
+### Added
 * added extra line cleanup after release
 
 
 ## 0.3.5 - (2017-06-10)
 ---
 
-### Changes
+### Changed
 * update python versions
 
 
 ## 0.3.4 - (2017-06-10)
 ---
 
-### Changes
+### Changed
 * update test coverage
 * add python versions to README.
 
@@ -108,7 +112,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 ## 0.3.3 - (2017-06-10)
 ---
 
-### Changes
+### Changed
 * add additional tests
 * refactor utils to be classed based for better testing
 
@@ -116,49 +120,49 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 ## 0.3.2 - (2017-06-09)
 ---
 
-### Fixes
+### Fixed
 * fix documentation typo
 
 
 ## 0.3.1 - (2017-06-09)
 ---
 
-### Changes
+### Changed
 * adding example changelog output to docs
 
 
 ## 0.3.0 - (2017-06-09)
 ---
 
-### New
+### Added
 * added current command
 
-### Changes
+### Changed
 * updating documentation
 
 
 ## 0.2.2 - (2017-06-09)
 ---
 
-### Changes
+### Changed
 * update documentation to rst for pypi
 
 
 ## 0.2.1 - (2017-06-09)
 ---
 
-### Fixes
+### Fixed
 * version number import
 
 
 ## 0.2.0 - (2017-06-09)
 ---
 
-### New
+### Added
 * Add suggest command
 * Add version option
 
-### Changes
+### Changed
 * changing hardcoded 'CHANGELOG.md' to variable for better mocking in tests
 * changing hardcoded  to variable for better mocking in tests
 * Updating tests
@@ -167,7 +171,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 ## 0.1.1 - (2017-06-09)
 ---
 
-### Changes
+### Changed
 * Add README badges
 * Add build tools
 
@@ -175,6 +179,6 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 ## 0.1.0 - (2017-06-09)
 ---
 
-### New
+### Added
 * Setup initial Project
 * Setup Build tools

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 
 A command line interface for managing your CHANGELOG.md files. Designed to make it easy to manage your repositories
-release history according to [Keep a Changelog](http://keepachangelog.com/).
+release history according to [Keep a Changelog](http://keepachangelog.com/) v1.1.0.
 
 ## Installation
 install using `pip` via:
@@ -18,15 +18,15 @@ pip install changelog-cli
 
 
 ## How To
-To keep an accurate changelog, whenenever you commit a change that affects how end users use
+To keep an accurate changelog, whenever you commit a change that affects how end users use
 your project, use this command line tool to add a line to the changelog. 
 
-If you added a new feature, use something like `changelog new "added feature x"`. This will add a
-line to your `CHANGELOG.md` under the `### New` section. 
+If you added a new feature, use something like `changelog added "added feature x"`. This will add a
+line to your `CHANGELOG.md` under the `### Added` section. 
 
 When you are ready for release, run `changelog release` and that will infer the correct semantic 
-version based on the types of changes since the last release. For example your `new` change should
-prompt a `minor (0.X.0)` release. A `breaks` change would prompt a `major (X.0.0)` version bump and `fix` or `change` changes
+version based on the types of changes since the last release. For example your `added` change should
+prompt a `minor (0.X.0)` release. A `removed` change would prompt a `major (X.0.0)` version bump and `fixed` or `changed` changes
  would prompt a `patch (0.0.X)`.
  
 You can manually override what type of of release via `changelog release --minor` using the `--patch`, `--minor` or `--major`
@@ -36,7 +36,7 @@ flags.
 ## Commands
 `changelog init` -> Creates a CHANGELOG.md with some basic documentation in it.
 
-`changelog (new|change|fix|breaks) "<message>"` -> adds a line to the appropriate section
+`changelog (added|changed|deprecated|removed|fixed|security) "<message>"` -> adds a line to the appropriate section
 
 `changelog release (--major|minor|patch|suggest) (--yes)` -> Cuts a release for the changelog, incrementing the version.
 
@@ -55,10 +55,10 @@ If you get tired of typing out `changelog` for every command, it can also be acc
 ```
 >>> changelog current
 1.4.1
->>> changelog new "add new feature x"
+>>> changelog added "add new feature x"
 >>> changelog suggest
 1.5.0
->>> changelog breaks "removing key feature y"
+>>> changelog removed "removing key feature y"
 >>> cl release
 Planning on releasing version 2.0.0. Proceed? [y/N]: n
 >>> cl release --minor
@@ -78,29 +78,32 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 ## Unreleased
 ---
 
-### New
+### Added
 
-### Changes
+### Changed
 
-### Fixes
+### Deprecated
 
-### Breaks
+### Removed
 
+### Fixed
+
+### Security
 
 ## 1.5.0 - (2017-06-09)
 ---
 
-### New
+### Added
 * add new feature x
 
-### Breaks
+### Removed
 * remove key feature y
 
 
 ## 1.4.1 - (2017-05-29)
 ---
 
-### Changes
+### Changed
 * updating documentation
 
 

--- a/src/changelog/templates.py
+++ b/src/changelog/templates.py
@@ -4,23 +4,6 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Changelog](http://keepachangelog.com/).
 """
 
-UNRELEASED = """
-## Unreleased
----
-
-### New
-
-### Changes
-
-### Fixes
-
-### Breaks
-
-
-"""
-
-INIT = BASE + UNRELEASED
-
 DEFAULT_VERSION = "0.0.0"
 
 RELEASE_LINE = "## {0} - ({1})\n"

--- a/src/changelog/utils.py
+++ b/src/changelog/utils.py
@@ -2,19 +2,18 @@ import os
 import re
 from datetime import date
 
-from changelog.templates import INIT, UNRELEASED, RELEASE_LINE, DEFAULT_VERSION, RELEASE_LINE_REGEXES
+from changelog.templates import BASE, RELEASE_LINE, DEFAULT_VERSION, RELEASE_LINE_REGEXES
 from changelog.exceptions import ChangelogDoesNotExistError
 
 
 class ChangelogUtils:
     CHANGELOG = 'CHANGELOG.md'
-    SECTIONS = {
-        'new': "### New\n",
-        'fix': "### Fixes\n",
-        'change': '### Changes\n',
-        'break': "### Breaks\n"
-    }
+    TYPES_OF_CHANGE = ['added', 'changed', 'deprecated', 'removed', 'fixed', 'security']
+    SECTIONS = {change_type: "### {}\n".format(change_type.capitalize()) for change_type in TYPES_OF_CHANGE}
     REVERSE_SECTIONS = {v: k for k, v in SECTIONS.items()}
+
+    UNRELEASED = "\n## Unreleased\n---\n\n" + ''.join(["{0}\n\n".format(section_header) for section_header in REVERSE_SECTIONS.keys()])
+    INIT = BASE + UNRELEASED
 
     def initialize_changelog_file(self):
         """
@@ -23,7 +22,7 @@ class ChangelogUtils:
         if os.path.isfile(self.CHANGELOG):
             return "{} already exists".format(self.CHANGELOG)
         with open(self.CHANGELOG, 'w') as changelog:
-            changelog.write(INIT)
+            changelog.write(self.INIT)
         return "Created {}".format(self.CHANGELOG)
 
     def get_changelog_data(self):
@@ -85,9 +84,9 @@ class ChangelogUtils:
     def get_release_suggestion(self):
         """Suggests a release type"""
         changes = self.get_changes()
-        if 'break' in changes:
+        if 'removed' in changes:
             return "major"
-        if 'new' in changes:
+        if 'added' in changes:
             return "minor"
         return "patch"
 
@@ -117,7 +116,7 @@ class ChangelogUtils:
             if reading and line in self.REVERSE_SECTIONS and self.REVERSE_SECTIONS[line] not in changes:
                 continue
             output.append(line)
-        output.insert(unreleased_position, UNRELEASED)
+        output.insert(unreleased_position, self.UNRELEASED)
         output = self.crunch_lines(output)
         self.write_changelog(output)
 

--- a/src/changelog/utils.py
+++ b/src/changelog/utils.py
@@ -12,6 +12,12 @@ class ChangelogUtils:
     SECTIONS = {change_type: "### {}\n".format(change_type.capitalize()) for change_type in TYPES_OF_CHANGE}
     REVERSE_SECTIONS = {v: k for k, v in SECTIONS.items()}
 
+    # These were the sections before v1.0.0
+    # Kept so that user from pre-v1.0.0 versions can upgrade
+    BETA_TYPES_OF_CHANGE = ['new', 'changes', 'fixes', 'breaks']
+    BETA_SECTIONS = {change_type: "### {}\n".format(change_type.capitalize()) for change_type in BETA_TYPES_OF_CHANGE}
+    BETA_REVERSE_SECTIONS = {v: k for k, v in BETA_SECTIONS.items()}
+
     UNRELEASED = "\n## Unreleased\n---\n\n" + ''.join(["{0}\n\n".format(section_header) for section_header in REVERSE_SECTIONS.keys()])
     INIT = BASE + UNRELEASED
 
@@ -73,6 +79,9 @@ class ChangelogUtils:
                 if line in self.REVERSE_SECTIONS:
                     section = self.REVERSE_SECTIONS[line]
                     continue
+                elif line in self.BETA_REVERSE_SECTIONS:
+                    section = self.BETA_REVERSE_SECTIONS[line]
+                    continue
                 changes[section] = line.strip().lstrip("* ")
                 continue
             if line == "## Unreleased\n":
@@ -84,9 +93,9 @@ class ChangelogUtils:
     def get_release_suggestion(self):
         """Suggests a release type"""
         changes = self.get_changes()
-        if 'removed' in changes:
+        if 'removed' in changes or 'breaks' in changes:
             return "major"
-        if 'added' in changes:
+        if 'added' in changes or 'new' in changes:
             return "minor"
         return "patch"
 

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -44,85 +44,85 @@ class CliIntegrationTestCase(unittest.TestCase):
         result = self.runner.invoke(cli, ['--version'])
         self.assertTrue(result)
 
-    def test_cli_new(self):
+    def test_cli_added(self):
         with self.runner.isolated_filesystem():
             self.runner.invoke(cli, ['init'])
-            result = self.runner.invoke(cli, ['new', 'Adding a new feature'])
+            result = self.runner.invoke(cli, ['added', 'Adding a new feature'])
             self.assertTrue(result)
             suggest = self.runner.invoke(cli, ['suggest'])
             self.assertEqual(suggest.output.strip(), '0.1.0')
 
-    def test_cli_new_missing(self):
+    def test_cli_added_missing(self):
         with self.runner.isolated_filesystem():
-            result = self.runner.invoke(cli, ['new', 'Adding a new feature'], input='y\n')
-            self.assertEqual(result.output.strip(), 'No CHANGELOG.md Found, do you want to create one? [y/N]: y')
+            result = self.runner.invoke(cli, ['added', 'Adding a new feature'], input='y\n')
+            self.assertEqual(result.output.strip(), 'No CHANGELOG.md found, do you want to create one? [y/N]: y')
 
-    def test_cli_change(self):
+    def test_cli_changed(self):
         with self.runner.isolated_filesystem():
             self.runner.invoke(cli, ['init'])
-            result = self.runner.invoke(cli, ['change', 'Changing a feature'])
+            result = self.runner.invoke(cli, ['changed', 'Changing a feature'])
             self.assertTrue(result)
             suggest = self.runner.invoke(cli, ['suggest'])
             self.assertEqual(suggest.output.strip(), '0.0.1')
 
-    def test_cli_change_missing(self):
+    def test_cli_changed_missing(self):
         with self.runner.isolated_filesystem():
-            result = self.runner.invoke(cli, ['change', 'changing a feature'], input='y\n')
-            self.assertEqual(result.output.strip(), 'No CHANGELOG.md Found, do you want to create one? [y/N]: y')
+            result = self.runner.invoke(cli, ['changed', 'changing a feature'], input='y\n')
+            self.assertEqual(result.output.strip(), 'No CHANGELOG.md found, do you want to create one? [y/N]: y')
 
-    def test_cli_fix(self):
+    def test_cli_fixed(self):
         with self.runner.isolated_filesystem():
             self.runner.invoke(cli, ['init'])
-            result = self.runner.invoke(cli, ['fix', 'Fix a Bug'])
+            result = self.runner.invoke(cli, ['fixed', 'Fix a Bug'])
             self.assertTrue(result)
             suggest = self.runner.invoke(cli, ['suggest'])
             self.assertEqual(suggest.output.strip(), '0.0.1')
 
-    def test_cli_suggest_type_fix(self):
+    def test_cli_suggest_type_fixed(self):
         with self.runner.isolated_filesystem():
             self.runner.invoke(cli, ['init'])
-            result = self.runner.invoke(cli, ['fix', 'Fix a Bug'])
+            result = self.runner.invoke(cli, ['fixed', 'Fix a Bug'])
             self.assertTrue(result)
             suggest = self.runner.invoke(cli, ['suggest', '--type'])
             self.assertEqual(suggest.output.strip(), 'patch')
 
-    def test_cli_fix_missing(self):
+    def test_cli_fixed_missing(self):
         with self.runner.isolated_filesystem():
-            result = self.runner.invoke(cli, ['fix', 'Fix a Bug'], input='y\n')
-            self.assertEqual(result.output.strip(), 'No CHANGELOG.md Found, do you want to create one? [y/N]: y')
+            result = self.runner.invoke(cli, ['fixed', 'Fix a Bug'], input='y\n')
+            self.assertEqual(result.output.strip(), 'No CHANGELOG.md found, do you want to create one? [y/N]: y')
 
-    def test_cli_breaks(self):
+    def test_cli_removed(self):
         with self.runner.isolated_filesystem():
             self.runner.invoke(cli, ['init'])
-            result = self.runner.invoke(cli, ['breaks', 'Breaking Change'])
+            result = self.runner.invoke(cli, ['removed', 'Breaking Change'])
             self.assertTrue(result)
             suggest = self.runner.invoke(cli, ['suggest'])
             self.assertEqual(suggest.output.strip(), '1.0.0')
 
-    def test_cli_suggest_type_breaks(self):
+    def test_cli_suggest_type_removed(self):
         with self.runner.isolated_filesystem():
             self.runner.invoke(cli, ['init'])
-            result = self.runner.invoke(cli, ['breaks', 'Breaking Change'])
+            result = self.runner.invoke(cli, ['removed', 'Breaking Change'])
             self.assertTrue(result)
             suggest = self.runner.invoke(cli, ['suggest', '--type'])
             self.assertEqual(suggest.output.strip(), 'major')
 
-    def test_cli_breaks_missing(self):
+    def test_cli_removed_missing(self):
         with self.runner.isolated_filesystem():
-            result = self.runner.invoke(cli, ['breaks', 'Breaking Change'], input='y\n')
-            self.assertEqual(result.output.strip(), 'No CHANGELOG.md Found, do you want to create one? [y/N]: y')
+            result = self.runner.invoke(cli, ['removed', 'Breaking Change'], input='y\n')
+            self.assertEqual(result.output.strip(), 'No CHANGELOG.md found, do you want to create one? [y/N]: y')
 
     def test_cli_release(self):
         with self.runner.isolated_filesystem():
             self.runner.invoke(cli, ['init'])
-            self.runner.invoke(cli, ['new', 'Adding a new feature'])
+            self.runner.invoke(cli, ['added', 'Adding a new feature'])
             result = self.runner.invoke(cli, ['release'])
             self.assertEqual(result.output.strip(), 'Planning on releasing version 0.1.0. Proceed? [y/N]:')
 
     def test_cli_release_y(self):
         with self.runner.isolated_filesystem():
             self.runner.invoke(cli, ['init'])
-            self.runner.invoke(cli, ['new', 'Adding a new feature'])
+            self.runner.invoke(cli, ['added', 'Adding a new feature'])
             result = self.runner.invoke(cli, ['release', '--yes'])
             self.assertTrue(result)
             suggest = self.runner.invoke(cli, ['current'])
@@ -131,11 +131,11 @@ class CliIntegrationTestCase(unittest.TestCase):
     def test_cli_release_missing(self):
         with self.runner.isolated_filesystem():
             result = self.runner.invoke(cli, ['release'])
-            self.assertEqual(result.output.strip(), 'No CHANGELOG.md Found, do you want to create one? [y/N]:')
+            self.assertEqual(result.output.strip(), 'No CHANGELOG.md found, do you want to create one? [y/N]:')
 
     def test_cli_view(self):
         with self.runner.isolated_filesystem():
             self.runner.invoke(cli, ['init'])
-            self.runner.invoke(cli, ['new', 'Adding a new feature'])
+            self.runner.invoke(cli, ['added', 'Adding a new feature'])
             result = self.runner.invoke(cli, ['view'])
             self.assertTrue(result)

--- a/tests/integration/test_deterministic.py
+++ b/tests/integration/test_deterministic.py
@@ -5,15 +5,11 @@ import random
 from click.testing import CliRunner
 
 from changelog.commands import cli
+from changelog.utils import ChangelogUtils
 
 START = random.getstate()
 
-OPTIONS = [
-    ("new", "Adding a new feature {}"),
-    ("change", "Changing a feature {}"),
-    ("fix", "fix a bug {}"),
-    ("breaks", "breaking change {}"),
-]
+OPTIONS = [(section, "{}{{}}".format(section)) for section in ChangelogUtils.TYPES_OF_CHANGE]
 
 
 class CliDeterministicTestCase(unittest.TestCase):
@@ -27,7 +23,7 @@ class CliDeterministicTestCase(unittest.TestCase):
         # first pass
         with self.runner.isolated_filesystem():
             self.runner.invoke(cli, ['init'])
-            self.runner.invoke(cli, ['new', "First Feature"])
+            self.runner.invoke(cli, ['added', "First Feature"])
             self.runner.invoke(cli, ['release', '--yes'])
             for i in range(random.randrange(10)):
                 for j in range(random.randrange(3)):
@@ -42,7 +38,7 @@ class CliDeterministicTestCase(unittest.TestCase):
         # second pass
         with self.runner.isolated_filesystem():
             self.runner.invoke(cli, ['init'])
-            self.runner.invoke(cli, ['new', "First Feature"])
+            self.runner.invoke(cli, ['added', "First Feature"])
             self.runner.invoke(cli, ['release', '--yes'])
             for i in range(random.randrange(10)):
                 for j in range(random.randrange(3)):
@@ -53,4 +49,3 @@ class CliDeterministicTestCase(unittest.TestCase):
             with open("CHANGELOG.md", 'r') as second_pass_file:
                 second_pass = second_pass_file.read()
         self.assertEqual(first_pass, second_pass)
-

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -47,19 +47,19 @@ class UtilsTestCase(unittest.TestCase):
         self.assertEqual(self.cl.crunch_lines(document), ['this\n', '---\n', '\n', 'that\n'])
 
     def test_get_release_suggestion_patch(self):
-        with patch.object(ChangelogUtils, 'get_changes', return_value={'changes': ''}):
+        with patch.object(ChangelogUtils, 'get_changes', return_value={'changed': ''}):
             CL = ChangelogUtils()
             result = CL.get_release_suggestion()
             self.assertEqual(result, 'patch')
 
     def test_get_release_suggestion_minor(self):
-        with patch.object(ChangelogUtils, 'get_changes', return_value={'new': 'stuff'}):
+        with patch.object(ChangelogUtils, 'get_changes', return_value={'added': 'stuff'}):
             CL = ChangelogUtils()
             result = CL.get_release_suggestion()
             self.assertEqual(result, 'minor')
 
     def test_get_release_suggestion_major(self):
-        with patch.object(ChangelogUtils, 'get_changes', return_value={'break': 'stuff'}):
+        with patch.object(ChangelogUtils, 'get_changes', return_value={'removed': 'stuff'}):
             CL = ChangelogUtils()
             result = CL.get_release_suggestion()
             self.assertEqual(result, 'major')
@@ -70,25 +70,25 @@ class UtilsTestCase(unittest.TestCase):
                 "## Unreleased\n",
                 "---\n",
                 "\n",
-                "### New\n",
+                "### Added\n",
                 "\n",
-                "### Fixes\n",
+                "### Fixed\n",
                 "\n",
-                "### Breaks\n",
+                "### Removed\n",
             ]
             with patch.object(ChangelogUtils, 'get_changelog_data', return_value=sample_data) as mock_read:
                 CL = ChangelogUtils()
-                CL.update_section("new", 'this is a test')
+                CL.update_section("added", 'this is a test')
         mock_write.assert_called_once_with([
             "## Unreleased\n",
             "---\n",
             "\n",
-            "### New\n",
+            "### Added\n",
             "* this is a test\n",
             "\n",
-            "### Fixes\n",
+            "### Fixed\n",
             "\n",
-            "### Breaks\n",
+            "### Removed\n",
         ])
 
     def test_get_current_version(self):
@@ -96,11 +96,11 @@ class UtilsTestCase(unittest.TestCase):
             "## Unreleased\n",
             "---\n",
             "\n",
-            "### New\n",
+            "### Added\n",
             "\n",
-            "### Fixes\n",
+            "### Fixed\n",
             "\n",
-            "### Breaks\n",
+            "### Removed\n",
             "\n",
             "\n",
             "## 0.3.2 - (2017-06-09)\n",
@@ -123,13 +123,13 @@ class UtilsTestCase(unittest.TestCase):
             "## Unreleased\n",
             "---\n",
             "\n",
-            "### New\n",
+            "### Added\n",
             "* added feature x\n",
             "\n",
-            "### Fixes\n",
+            "### Fixed\n",
             "* fixed bug 1\n",
             "\n",
-            "### Breaks\n",
+            "### Removed\n",
             "\n",
             "\n",
             "## 0.3.2 - (2017-06-09)\n",
@@ -138,8 +138,8 @@ class UtilsTestCase(unittest.TestCase):
         with patch.object(ChangelogUtils, 'get_changelog_data', return_value=sample_data) as mock_read:
             CL = ChangelogUtils()
             result = CL.get_changes()
-        self.assertTrue('new' in result)
-        self.assertTrue('fix' in result)
+        self.assertTrue('added' in result)
+        self.assertTrue('fixed' in result)
 
     def test_get_new_release_version_patch(self):
         with patch.object(ChangelogUtils, 'get_current_version', return_value='1.1.1'):
@@ -196,12 +196,12 @@ class ChangelogFileOperationTestCase(unittest.TestCase):
 
     def test_cut_release(self):
         self.CL.initialize_changelog_file()
-        self.CL.update_section('new', "this is a test")
+        self.CL.update_section('added', "this is a test")
         self.CL.cut_release('suggest')
         data = self.CL.get_changelog_data()
         self.assertTrue('## Unreleased\n' in data)
         self.assertTrue('## 0.1.0 - ({})\n'.format(date.today().isoformat()) in data)
-        self.CL.update_section('break', "removed a thing")
+        self.CL.update_section('removed', "removed a thing")
         self.CL.cut_release('suggest')
         data2 = self.CL.get_changelog_data()
         self.assertTrue('## Unreleased\n' in data2)
@@ -211,7 +211,7 @@ class ChangelogFileOperationTestCase(unittest.TestCase):
         self.assertEqual(self.CL.match_version(line), '0.2.1')
 
     def test_match_version_miss(self):
-        line = '### Changes'
+        line = '### Changed'
         self.assertFalse(self.CL.match_version(line))
 
     def test_match_version_basic(self):


### PR DESCRIPTION
Fixes #5

Changes `changelog-cli` to use the [Keep A Changelog](https://keepachangelog.com/en) "Types of Changes" throughout.

It also autogenerates the headers throughout the code based on the set of change types.

It supports reading the current change type headers, but will only write the new v1.1 headers (ie. existing CHANGELOGs will start using the new headers on the next `changelog release`)