### PR TITLE
Drop support for Python 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "2.7"
   - "3.6"
   - "3.7"
   - "3.8"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 * Fix Description for pypi
 
 ### Breaks
+* Removed support for Python 2
 * Removed support for Python 3 prior to 3.6
 
 

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,6 @@ setup(
         'Environment :: Console',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',


### PR DESCRIPTION
@mc706 I'm not 100% sure that I read it right, but I think [this comment](https://github.com/mc706/changelog-cli/issues/18#issuecomment-762532578) says that you're okay with the idea of dropping Python 2.7 as well?

See PR #21 for modernization changes.