### PR TITLE
Return all changes in get_changes

### DIFF
--- a/src/changelog/utils.py
+++ b/src/changelog/utils.py
@@ -4,6 +4,7 @@ from datetime import date
 
 from changelog.templates import INIT, UNRELEASED, RELEASE_LINE, DEFAULT_VERSION, RELEASE_LINE_REGEXES
 from changelog.exceptions import ChangelogDoesNotExistError
+from collections import defaultdict
 
 
 class ChangelogUtils:
@@ -60,9 +61,9 @@ class ChangelogUtils:
         return DEFAULT_VERSION
 
     def get_changes(self):
-        """Get the list of chances since the last release"""
+        """Get the changes since the last release"""
         data = self.get_changelog_data()
-        changes = {}
+        changes = defaultdict(list)
         reading = False
         section = None
         for line in data:
@@ -74,7 +75,7 @@ class ChangelogUtils:
                 if line in self.REVERSE_SECTIONS:
                     section = self.REVERSE_SECTIONS[line]
                     continue
-                changes[section] = line.strip().lstrip("* ")
+                changes[section].append(line.strip().lstrip("* "))
                 continue
             if line == "## Unreleased\n":
                 reading = True

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -128,6 +128,7 @@ class UtilsTestCase(unittest.TestCase):
             "\n",
             "### Fixes\n",
             "* fixed bug 1\n",
+            "* fixed bug 2\n",
             "\n",
             "### Breaks\n",
             "\n",
@@ -138,8 +139,8 @@ class UtilsTestCase(unittest.TestCase):
         with patch.object(ChangelogUtils, 'get_changelog_data', return_value=sample_data) as mock_read:
             CL = ChangelogUtils()
             result = CL.get_changes()
-        self.assertTrue('new' in result)
-        self.assertTrue('fix' in result)
+        expected = {'new': ['added feature x'], 'fix': ['fixed bug 1', 'fixed bug 2']}
+        self.assertEqual(expected, result)
 
     def test_get_new_release_version_patch(self):
         with patch.object(ChangelogUtils, 'get_current_version', return_value='1.1.1'):


### PR DESCRIPTION
One of the ways to fix #23.

Before, it would just return the last line of each section.
This worked fine, since nothing else in the code was actually reading the contents, just the existence of a section.

I think I slightly prefer #24 as a solution to this problem though.

Fixes #23

---

I noticed this while adding the typing information in #21 