### PR TITLE
Remove patch workaround for Python 2

### DIFF
--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,11 +1,7 @@
 import unittest
 import os
 from datetime import date
-
-try:
-    from unittest.mock import patch
-except ImportError:
-    from mock import patch
+from unittest.mock import patch
 
 from changelog.utils import ChangelogUtils
 from changelog.exceptions import ChangelogDoesNotExistError


### PR DESCRIPTION
`unittest.mock` exists from Python 3.3 onward.