### PR TITLE
keeping format of release line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
   * Existing CHANGELOGs will start using these headers after the new run of `changelog release`
 
 ### Fixed
+* keeping format of `release line`
 * Fix Description for pypi
 
 ### Removed

--- a/src/changelog/templates.py
+++ b/src/changelog/templates.py
@@ -6,10 +6,14 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 
 DEFAULT_VERSION = "0.0.0"
 
-RELEASE_LINE = "## {} - ({})\n"
+RELEASE_LINE = {
+    "date": "## {} - ({})\n",
+    "pure": "## {}\n",
+    "bracket_date": "## [{}] - {}\n"
+}
 
-RELEASE_LINE_REGEXES = [
-    r"^##\s(?P<v>\d+\.\d+\.\d+)\s\-\s\(\d{4}-\d{2}-\d{2}\)$",
-    r"^##\sv?(?P<v>\d+\.\d+\.\d+)",
-    r"^##\s\[(?P<v>\d+\.\d+\.\d+)\]\s\-\s\d{4}-\d{2}-\d{2}$",
-]
+RELEASE_LINE_REGEXES = {
+    "date": r"^##\s(?P<v>\d+\.\d+\.\d+)\s\-\s\(\d{4}-\d{2}-\d{2}\)$",
+    "pure": r"^##\sv?(?P<v>\d+\.\d+\.\d+)",
+    "bracket_date": r"^##\s\[(?P<v>\d+\.\d+\.\d+)\]\s\-\s\d{4}-\d{2}-\d{2}$"
+}

--- a/src/changelog/utils.py
+++ b/src/changelog/utils.py
@@ -22,6 +22,7 @@ class ChangelogUtils:
 
     UNRELEASED: str = "\n## Unreleased\n---\n\n" + ''.join([f"{section_header}\n\n" for section_header in REVERSE_SECTIONS.keys()])
     INIT: str = BASE + UNRELEASED
+    VERSION_FORMAT: str = "date"
 
     def initialize_changelog_file(self) -> str:
         """
@@ -123,7 +124,7 @@ class ChangelogUtils:
                 reading = False
             if line == "## Unreleased\n":
                 unreleased_position = i
-                line = RELEASE_LINE.format(new_version, date.today().isoformat())
+                line = RELEASE_LINE[self.VERSION_FORMAT].format(new_version, date.today().isoformat())
             if reading and line in self.REVERSE_SECTIONS and self.REVERSE_SECTIONS[line] not in change_types:
                 continue
             output.append(line)
@@ -167,8 +168,9 @@ class ChangelogUtils:
         """
         Matches a line vs the list of version strings. Returns group, or None if no match is found.
         """
-        for regex in RELEASE_LINE_REGEXES:
+        for version_format, regex in RELEASE_LINE_REGEXES.items():
             match = re.match(regex, line)
             if match and match.group('v'):
+                self.VERSION_FORMAT = version_format
                 return match.group('v')
         return None


### PR DESCRIPTION
resolves issue #29
Release line is kept in format in which is found (based on version resolving).
When there is no version yet, it uses release line format as usual