### PR TITLE
Format release lines in the same format that keepachangelog.com does

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
   * Existing CHANGELOGs will start using these headers after the new run of `changelog release`
 
 ### Fixed
+* Format release lines in the same format that keepachangelog.com does
 * Fix Description for pypi
 
 ### Removed
@@ -24,84 +25,84 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 * Removed support for Python 3 prior to 3.7
 * Removed the previous CLI flags for the change type headers: `--new`, `--change`, `--fix`, `--breaks`
 
-## 0.7.0 - (2020-02-09)
+## [0.7.0] - 2020-02-09
 ---
 
 ### Added
 * Expose the type of release with `changelog suggest --type`
 
 
-## 0.6.2 - (2017-10-27)
+## [0.6.2] - 2017-10-27
 ---
 
 ### Fixed
 * update init template
 
 
-## 0.6.1 - (2017-07-17)
+## [0.6.1] - 2017-07-17
 ---
 
 ### Changed
 * add determinism fuzz testing
 
 
-## 0.6.0 - (2017-07-16)
+## [0.6.0] - 2017-07-16
 ---
 
 ### Added
 * add view command
 
 
-## 0.5.4 - (2017-07-16)
+## [0.5.4] - 2017-07-16
 ---
 
 ### Changed
 * add 'keep a changelog' regex for parsing
 
 
-## 0.5.3 - (2017-06-16)
+## [0.5.3] - 2017-06-16
 ---
 
 ### Fixed
 * start first release at 0.1.0
 
 
-## 0.5.2 - (2017-06-13)
+## [0.5.2] - 2017-06-13
 ---
 
 ### Fixed
 * fixing documentation formatting
 
 
-## 0.5.1 - (2017-06-13)
+## [0.5.1] - 2017-06-13
 ---
 
 ### Fixed
 * unreleased position in files with shorter headers
 
 
-## 0.5.0 - (2017-06-13)
+## [0.5.0] - 2017-06-13
 ---
 
 ### Added
 * Added handling for additional version delimiter in changelog files
 
 
-## 0.4.0 - (2017-06-10)
+## [0.4.0] - 2017-06-10
 ---
 
 ### Added
 * added extra line cleanup after release
 
 
-## 0.3.5 - (2017-06-10)
+## [0.3.5] - 2017-06-10
 ---
 
 ### Changed
 * update python versions
 
 
-## 0.3.4 - (2017-06-10)
+## [0.3.4] - 2017-06-10
 ---
 
 ### Changed
@@ -109,7 +110,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 * add python versions to README.
 
 
-## 0.3.3 - (2017-06-10)
+## [0.3.3] - 2017-06-10
 ---
 
 ### Changed
@@ -117,21 +118,21 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 * refactor utils to be classed based for better testing
 
 
-## 0.3.2 - (2017-06-09)
+## [0.3.2] - 2017-06-09
 ---
 
 ### Fixed
 * fix documentation typo
 
 
-## 0.3.1 - (2017-06-09)
+## [0.3.1] - 2017-06-09
 ---
 
 ### Changed
 * adding example changelog output to docs
 
 
-## 0.3.0 - (2017-06-09)
+## [0.3.0] - 2017-06-09
 ---
 
 ### Added
@@ -141,21 +142,21 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 * updating documentation
 
 
-## 0.2.2 - (2017-06-09)
+## [0.2.2] - 2017-06-09
 ---
 
 ### Changed
 * update documentation to rst for pypi
 
 
-## 0.2.1 - (2017-06-09)
+## [0.2.1] - 2017-06-09
 ---
 
 ### Fixed
 * version number import
 
 
-## 0.2.0 - (2017-06-09)
+## [0.2.0] - 2017-06-09
 ---
 
 ### Added
@@ -168,7 +169,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 * Updating tests
 
 
-## 0.1.1 - (2017-06-09)
+## [0.1.1] - 2017-06-09
 ---
 
 ### Changed
@@ -176,7 +177,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 * Add build tools
 
 
-## 0.1.0 - (2017-06-09)
+## [0.1.0] - 2017-06-09
 ---
 
 ### Added

--- a/src/changelog/templates.py
+++ b/src/changelog/templates.py
@@ -6,7 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 
 DEFAULT_VERSION = "0.0.0"
 
-RELEASE_LINE = "## {} - ({})\n"
+RELEASE_LINE = "## [{}] - {}\n"
 
 RELEASE_LINE_REGEXES = [
     r"^##\s(?P<v>\d+\.\d+\.\d+)\s\-\s\(\d{4}-\d{2}-\d{2}\)$",

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -235,7 +235,7 @@ class ChangelogFileOperationTestCase(unittest.TestCase):
         self.CL.cut_release('suggest')
         data = self.CL.get_changelog_data()
         self.assertTrue('## Unreleased\n' in data)
-        self.assertTrue(f'## 0.1.0 - ({date.today().isoformat()})\n' in data)
+        self.assertTrue(f'## [0.1.0] - {date.today().isoformat()}\n' in data)
         self.CL.update_section('removed', "removed a thing")
         self.CL.cut_release('suggest')
         data2 = self.CL.get_changelog_data()
@@ -266,7 +266,7 @@ class ChangelogFileOperationTestCase(unittest.TestCase):
             CL.cut_release('suggest')
         data = CL.get_changelog_data()
         self.assertTrue('## Unreleased\n' in data)
-        self.assertTrue(f'## 0.4.0 - ({date.today().isoformat()})\n' in data)
+        self.assertTrue(f'## [0.4.0] - {date.today().isoformat()}\n' in data)
         # The beta headings still exist
         self.assertTrue('### New\n' in data)
         self.assertTrue('### Changes\n' in data)


### PR DESCRIPTION
### What are you trying to accomplish?

Fixes #29.

### What approach did you choose and why?

Just changing the format we produce to match the one that keepachangelog.com does (`## [1.1.0] - 2019-02-15`).
I then updated out existing CHANGELOG to match.

### What should reviewers focus on?

People who have been using `changelog-cli` will start getting a different version for their release lines. If they have tooling that is parsing these lines, it will no longer work.

Personally, I feel that this was a bug (we said that we followed the spec, but weren't), and so this is fixing the bug.
Alternatively, we could use @schunka's #30, but IMO that's complexity we don't need to support.

### The impact of these changes

We'll be consistent with keepachangelog.com

### Testing
<!--
Are there any test results or screenshots that would be useful to include? How can a reviewer try out your change?
-->

...

### Checklist

* [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
